### PR TITLE
Feat/gh action

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,11 +26,24 @@ jobs:
           chmod +x ./gradlew
           ./gradlew clean build
 
-      - name: Build docker image and push to docker hub # Docker 이미지를 빌드하고 Docker Hub에 푸시합니다.
-        run: |
-          docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ github.sha }} .
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ github.sha }}
+      - name: Set up Docker Buildx # Docker Buildx를 설정합니다.
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub # Docker Hub에 로그인합니다.
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image # Docker 이미지를 빌드하고 푸시합니다.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ github.sha }}
+          cache-from: type=gha # GitHub Actions 캐시를 사용합니다.
+          cache-to: type=gha,mode=max
+
 
   cd:
     runs-on: ubuntu-latest # ubuntu 최신 버전에서 script를 실행

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,10 +21,12 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Setup Gradle # Gradle을 설정합니다.
+      - name: Setup Gradle And Build # Gradle을 설정하고 빌드합니다.
         run: |
           chmod +x ./gradlew
           ./gradlew clean build
+          java -Djarmode=layertools -jar zzansuni-api-server/app/build/libs/app-0.0.1-SNAPSHOT.jar extract
+
 
       - name: Set up Docker Buildx # Docker Buildx를 설정합니다.
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-alpine
 WORKDIR /usr/src/app
-ARG JAR_FILE=zzansuni-api-server/app/build/libs/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
+COPY ./dependencies ./
+COPY ./spring-boot-loader ./
+COPY ./snapshot-dependencies ./
+COPY ./application ./
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## 🔎 작업 내용

스프링부트에서 `layered-JAR mode`라는 기능을 새로 알게되었는데, 
이걸 사용하면 도커이미지 빌드에서 JAR파일을 통째로 COPY 하는게 아니라

의존성계층 > 스프링부트 로더 계층 > 스냅숏 의존성 계층 > 애플리케이션 계층
순으로 COPY하게되서 도커빌드 시간 단축에 도움이 될거 같습니다

## 이미지 첨부

<!--- 
관련 이미지가 있다면 첨부해주세요.
복잡한 도메인로직이 있다면 플로우차트로 표현해주세요.
--->

## To Reviewers 📢
`./gradlew clean build` 이후 
`java -Djarmode=layertools -jar zzansuni-api-server/app/build/libs/app-0.0.1-SNAPSHOT.jar extract`
해당 명령어 수행시 `dependencies` `spring-boot-loader` `snapshot-dependencies` `application` 폴더가 생성됩니다!

그후 `java org.springframework.boot.loader.launch.JarLauncher`로 서버를 실행하면 됩니다.


## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #<issue>