### PR TITLE
Issue/54

### DIFF
--- a/core/src/main/java/org/haedal/zzansuni/core/api/ErrorCode.java
+++ b/core/src/main/java/org/haedal/zzansuni/core/api/ErrorCode.java
@@ -9,7 +9,11 @@ public enum ErrorCode {
     COMMON_SYSTEM_ERROR("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."), // 장애 상황
     COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
     COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
-    COMMON_ILLEGAL_STATUS("잘못된 상태값입니다.");
+    COMMON_ILLEGAL_STATUS("잘못된 상태값입니다."),
+    COMMON_INVALID_REQUEST("잘못된 요청입니다."),
+    COMMON_INVALID_METHOD("허용되지 않은 메소드입니다."),
+    COMMON_INVALID_MEDIA_TYPE("지원하지 않는 미디어 타입입니다."),
+    COMMON_NOT_ALLOWED("허용되지 않은 요청입니다.");
 
     private final String message;
 }

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/PagingRequest.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/PagingRequest.java
@@ -1,16 +1,25 @@
 package org.haedal.zzansuni.controller;
 
-import jakarta.validation.constraints.Min;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 
+@ParameterObject
 public record PagingRequest(
-        @Min(0)
-        int page,
+        @Parameter(description = "페이지 번호(0부터 시작)(null이면 0)")
+        Integer page,
+        @Parameter(description = "페이지 크기(null이면 20)")
         Integer size
 ) {
     public PagingRequest {
         if (size == null) {
             size = 20;
+        }
+        if(page == null){
+            page = 0;
+        }
+        if(page < 0){
+            throw new IllegalArgumentException("page는 0 이상이어야 합니다.");
         }
     }
 

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/auth/AuthReq.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/auth/AuthReq.java
@@ -1,5 +1,6 @@
 package org.haedal.zzansuni.controller.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.haedal.zzansuni.domain.auth.OAuth2Provider;
@@ -34,8 +35,10 @@ public class AuthReq {
 
     public record EmailLoginRequest(
             @NotBlank(message = "email은 필수입니다.")
+            @Schema(description = "이메일", example = "test@a.c")
             String email,
             @NotBlank(message = "password는 필수입니다.")
+            @Schema(description = "비밀번호", example = "test")
             String password
     ) {
     }

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/challenge/ChallengeReq.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/challenge/ChallengeReq.java
@@ -1,5 +1,6 @@
 package org.haedal.zzansuni.controller.challenge;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.haedal.zzansuni.domain.challengegroup.ChallengeCommand;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,6 +21,7 @@ public class ChallengeReq {
 
     public record ReviewCreate(
         String content,
+        @Schema(description = "평점", example = "5")
         Integer rating
     ) {
 

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/challengegroup/ChallengeGroupController.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/challengegroup/ChallengeGroupController.java
@@ -1,6 +1,7 @@
 package org.haedal.zzansuni.controller.challengegroup;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,9 @@ public class ChallengeGroupController {
     @GetMapping("/api/challengeGroups")
     public ApiResponse<PagingResponse<ChallengeGroupRes.Info>> getChallengesPaging(
             @Valid PagingRequest pagingRequest,
-            @RequestParam ChallengeCategory category
+            @RequestParam(required = false)
+            @Schema(description = "챌린지 카테고리(null이면 전체)", implementation = ChallengeCategory.class)
+            ChallengeCategory category
     ) {
         var page = challengeGroupQueryService.getChallengeGroupsPaging(pagingRequest.toPageable(), category);
         var response = PagingResponse.from(page, ChallengeGroupRes.Info::from);

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/user/UserController.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/user/UserController.java
@@ -45,10 +45,16 @@ public class UserController {
     @GetMapping("/api/user/strick")
     public ApiResponse<UserRes.Strick> getStrick(
             @AuthenticationPrincipal JwtUser jwtUser,
-            @RequestParam(required = false) LocalDate startDate, // false면 오늘
-            @RequestParam(required = false) LocalDate endDate // false면 365일전
+            UserReq.GetStrick request
     ) {
-        var userModelStrick = userService.getUserStrick(jwtUser.getId(), startDate, endDate);
+        if(request.startDate().isAfter(request.endDate())){
+            throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다.");
+        }
+        var userModelStrick = userService.getUserStrick(
+                jwtUser.getId(),
+                request.startDate(),
+                request.endDate()
+        );
         return ApiResponse.success(UserRes.Strick.from(userModelStrick));
     }
 

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/user/UserReq.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/controller/user/UserReq.java
@@ -1,7 +1,11 @@
 package org.haedal.zzansuni.controller.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import org.haedal.zzansuni.domain.user.UserCommand;
+import org.springdoc.core.annotations.ParameterObject;
+
+import java.time.LocalDate;
 
 public class UserReq {
     public record Update(
@@ -11,6 +15,23 @@ public class UserReq {
             return UserCommand.Update.builder()
                     .nickname(nickname)
                     .build();
+        }
+    }
+
+    @ParameterObject
+    public record GetStrick(
+            @Schema(description = "시작일(null이면 종료일보다 365일 전)", example = "2023-08-12")
+            LocalDate startDate,
+            @Schema(description = "종료일(null이면 현재일)", example = "2024-08-12")
+            LocalDate endDate
+    ){
+        public GetStrick{
+            if(endDate == null){
+                endDate = LocalDate.now();
+            }
+            if(startDate == null){
+                startDate = endDate.minusDays(365);
+            }
         }
     }
 }

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/domain/userchallenge/application/ChallengeReviewService.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/domain/userchallenge/application/ChallengeReviewService.java
@@ -29,8 +29,8 @@ public class ChallengeReviewService {
      */
     @Transactional
     public Long createReview(ChallengeCommand.ReviewCreate command, Long challengeId, Long userId) {
-        UserChallenge userChallenge = userChallengeReader.getByUserIdAndChallengeId(userId,
-                challengeId);
+        UserChallenge userChallenge = userChallengeReader.findByUserIdAndChallengeId(userId,
+                challengeId).orElseThrow(() -> new IllegalStateException("해당 챌린지 참여 기록이 없습니다."));
 
         //이미 리뷰를 작성했는지 확인
         challengeReviewReader.findByUserChallengeId(userChallenge.getId())

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/global/api/ApiControllerAdvice.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/global/api/ApiControllerAdvice.java
@@ -171,7 +171,8 @@ public class ApiControllerAdvice {
             @AuthenticationPrincipal JwtUser jwtUser
     ) {
         String eventId = MDC.get(CommonHttpRequestInterceptor.HEADER_REQUEST_UUID_KEY);
-        log.error("eventId = {}, userId = {} ", eventId, jwtUser.getId(), e);
+        String userId = jwtUser == null ? "anonymous" : jwtUser.getId().toString();
+        log.error("eventId = {}, userId = {} ", eventId, userId, e);
         String message = ErrorCode.COMMON_SYSTEM_ERROR.getMessage() + "(eventId: " + eventId + ")";
         return ApiResponse.fail(ErrorCode.COMMON_SYSTEM_ERROR.name(), message);
     }

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/global/api/SwaggerConfig.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/global/api/SwaggerConfig.java
@@ -1,32 +1,35 @@
 package org.haedal.zzansuni.global.api;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.servers.Server;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "https://api.reditus.site",description = "Prod Server"),
-                @Server(url = "http://localhost:8080", description = "localhost"),
-        }
-)
+import java.util.List;
+
+
 @Configuration
 public class SwaggerConfig {
     private static final String BEARER_KEY = "bearer-key";
     @Bean
-    public OpenAPI openAPI() {
+    public OpenAPI openAPI(
+            Server server
+    ) {
         var securityRequirement = new SecurityRequirement();
         securityRequirement.addList(BEARER_KEY);
 
         return new OpenAPI()
                 .components(components())
                 .info(info())
+                .servers(List.of(server))
                 .addSecurityItem(securityRequirement);
     }
 
@@ -48,5 +51,21 @@ public class SwaggerConfig {
                 .title("Zzansuni API")
                 .description("Zzansuni API 명세서")
                 .version("1.0.0");
+    }
+
+    @Bean
+    public Server getLocalServer() {
+        return new Server().url("http://localhost:8080")
+                .description("Local Server");
+    }
+
+    @Bean
+    @Primary
+    @Profile("prod")
+    public Server getProductServer(
+            @Value("${server-url}")
+            String serverUrl
+    ) {
+        return new Server().url(serverUrl).description("Product Server");
     }
 }

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/challengegroup/adapter/ChallengeGroupReaderImpl.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/challengegroup/adapter/ChallengeGroupReaderImpl.java
@@ -60,13 +60,18 @@ public class ChallengeGroupReaderImpl implements ChallengeGroupReader {
                 .where(categoryEq)
                 .fetchOne();
 
+        List<Long> challengeGroupIds = queryFactory
+                .select(challengeGroup.id)
+                .from(challengeGroup)
+                .where(categoryEq)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
         List<ChallengeGroup> page = queryFactory
                 .selectFrom(challengeGroup)
-                .where(categoryEq)
                 .leftJoin(challengeGroup.challenges).fetchJoin()
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .where(challengeGroup.id.in(challengeGroupIds))
                 .fetch();
 
         return new PageImpl<>(page, pageable, count == null ? 0 : count);

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/challengegroup/adapter/ChallengeGroupReaderImpl.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/challengegroup/adapter/ChallengeGroupReaderImpl.java
@@ -1,6 +1,7 @@
 package org.haedal.zzansuni.infrastructure.challengegroup.adapter;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -48,15 +49,21 @@ public class ChallengeGroupReaderImpl implements ChallengeGroupReader {
 
     @Override
     public Page<ChallengeGroup> getChallengeGroupsPagingByCategory(Pageable pageable, ChallengeCategory category) {
+
+
+        BooleanExpression categoryEq = category == null ?
+                null : challengeGroup.category.eq(category);
+
         Long count = queryFactory
                 .select(challengeGroup.count())
                 .from(challengeGroup)
-                .where(challengeGroup.category.eq(category))
+                .where(categoryEq)
                 .fetchOne();
+
 
         List<ChallengeGroup> page = queryFactory
                 .selectFrom(challengeGroup)
-                .where(challengeGroup.category.eq(category))
+                .where(categoryEq)
                 .leftJoin(challengeGroup.challenges).fetchJoin()
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/challengegroup/adapter/ChallengeGroupReaderImpl.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/challengegroup/adapter/ChallengeGroupReaderImpl.java
@@ -6,19 +6,17 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.haedal.zzansuni.domain.challengegroup.ChallengeCategory;
 import org.haedal.zzansuni.domain.challengegroup.ChallengeGroup;
-import org.haedal.zzansuni.domain.challengegroup.application.ChallengeGroupModel;
 import org.haedal.zzansuni.domain.challengegroup.port.ChallengeGroupReader;
-import org.haedal.zzansuni.domain.user.QUser;
 import org.haedal.zzansuni.domain.user.User;
 import org.haedal.zzansuni.domain.user.UserModel;
 import org.haedal.zzansuni.domain.userchallenge.ChallengeGroupUserExp;
 import org.haedal.zzansuni.domain.userchallenge.QChallengeGroupUserExp;
 import org.haedal.zzansuni.domain.userchallenge.application.ChallengeGroupRankingModel;
 import org.haedal.zzansuni.infrastructure.challengegroup.ChallengeGroupRepository;
+import org.haedal.zzansuni.infrastructure.user.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -31,8 +29,9 @@ import static org.haedal.zzansuni.domain.challengegroup.QChallengeGroup.challeng
 @RequiredArgsConstructor
 public class ChallengeGroupReaderImpl implements ChallengeGroupReader {
     private final JPAQueryFactory queryFactory;
-    private final JdbcTemplate jdbcTemplate;
     private final ChallengeGroupRepository challengeGroupRepository;
+    private final UserRepository userRepository;
+
     @Override
     public ChallengeGroup getById(Long challengeGroupId) {
         return challengeGroupRepository
@@ -88,37 +87,42 @@ public class ChallengeGroupReaderImpl implements ChallengeGroupReader {
     }
 
 
+    /**
+     * 1. userId로 유저 엔터티 조회
+     * 2. challengeGroupId, userId로 `챌린지그룹 유저 경험치`조회
+     * 3. 해당 challgneGroupUserExp보다 totalExp가 큰 로우 개수 조회
+     */
     @Override
     public ChallengeGroupRankingModel.Main getRanking(Long challengeGroupId, Long userId) {
-        User user = queryFactory
-                .selectFrom(QUser.user)
-                .where(QUser.user.id.eq(userId))
-                .fetchOne();
-        if(user == null) {
-            throw new NoSuchElementException();
-        }
-
-        String sql = "SELECT ranked.rank1 FROM (" +
-                "  SELECT user_id, RANK() OVER (ORDER BY total_exp DESC) as rank1 " +
-                "  FROM challenge_group_user_exp " +
-                "  WHERE challenge_group_id = ?" +
-                ") as ranked " +
-                "WHERE ranked.user_id = ?";
-
-        Integer rank = jdbcTemplate.queryForObject(sql, Integer.class, challengeGroupId, userId);
-
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(NoSuchElementException::new);
 
         ChallengeGroupUserExp challengeGroupUserExp = queryFactory
                 .select(QChallengeGroupUserExp.challengeGroupUserExp)
                 .from(QChallengeGroupUserExp.challengeGroupUserExp)
-                .where(QChallengeGroupUserExp.challengeGroupUserExp.challengeGroup.id.eq(challengeGroupId)
-                        .and(QChallengeGroupUserExp.challengeGroupUserExp.user.id.eq(userId)))
+                .where(
+                        QChallengeGroupUserExp.challengeGroupUserExp.challengeGroup.id.eq(challengeGroupId),
+                        QChallengeGroupUserExp.challengeGroupUserExp.user.id.eq(userId))
                 .fetchOne();
+        Integer accumulatedPoint = challengeGroupUserExp != null ? challengeGroupUserExp.getTotalExp() : 0;
+
+        Long count = queryFactory
+                .select(QChallengeGroupUserExp.challengeGroupUserExp.count())
+                .from(QChallengeGroupUserExp.challengeGroupUserExp)
+                .where(
+                        QChallengeGroupUserExp.challengeGroupUserExp.challengeGroup.id.eq(challengeGroupId),
+                        QChallengeGroupUserExp.challengeGroupUserExp.totalExp.gt(accumulatedPoint)
+                )
+                .fetchOne();
+        assert count != null;
+        Integer rank = Integer.parseInt(count.toString()) + 1;
+
 
         return ChallengeGroupRankingModel.Main.builder()
-                .rank(rank==null ? 0 : rank)
-                .accumulatedPoint(challengeGroupUserExp != null ? challengeGroupUserExp.getTotalExp() : 0)
                 .user(UserModel.Main.from(user))
+                .rank(rank)
+                .accumulatedPoint(accumulatedPoint)
                 .build();
     }
 

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/userchallenge/UserChallengeRepository.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/userchallenge/UserChallengeRepository.java
@@ -12,7 +12,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
-    Optional<UserChallenge> findByUserIdAndChallenge_Id(Long userId, Long challengeId);
+    @Query("SELECT uc FROM UserChallenge uc " +
+            "WHERE uc.user.id = :userId " +
+            "AND uc.challenge.id = :challengeId")
+    Optional<UserChallenge> findByUserIdAndChallengeId(
+            @Param("userId") Long userId,
+            @Param("challengeId") Long challengeId
+    );
 
     /**
      * [challengeVerifications]와 [challenge]를 [fetchJoin]으로 OneToMany를 가져온다.

--- a/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/userchallenge/adapter/UserChallengeReaderImpl.java
+++ b/zzansuni-api-server/app/src/main/java/org/haedal/zzansuni/infrastructure/userchallenge/adapter/UserChallengeReaderImpl.java
@@ -59,7 +59,7 @@ public class UserChallengeReaderImpl implements UserChallengeReader {
 
     @Override
     public Optional<UserChallenge> findByUserIdAndChallengeId(Long userId, Long challengeId) {
-        return userChallengeRepository.findByUserIdAndChallenge_Id(userId, challengeId);
+        return userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId);
     }
 
     /**

--- a/zzansuni-api-server/app/src/main/resources/application.yml
+++ b/zzansuni-api-server/app/src/main/resources/application.yml
@@ -31,6 +31,7 @@ logging.level:
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+  use-fqn: true
 jwt:
   secret: ${JWT_SECRET:4099a46b-39db-4860-a61b-2ae76ea24c43}
   access-token-expire-time: 1800000 # 30 minutes
@@ -109,3 +110,4 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
 naver:
   client-secret: ${NAVER_CLIENT_SECRET}
+server-url: 'https://api.reditus.site'

--- a/zzansuni-api-server/app/src/test/java/org/haedal/zzansuni/domain/challengegroup/challenge/RecordServiceTest.java
+++ b/zzansuni-api-server/app/src/test/java/org/haedal/zzansuni/domain/challengegroup/challenge/RecordServiceTest.java
@@ -154,8 +154,8 @@ class RecordServiceTest {
         ChallengeCommand.ReviewCreate command = new ChallengeCommand.ReviewCreate(
             "Great challenge!", 5);
 
-        when(userChallengeReader.getByUserIdAndChallengeId(userId, challengeId)).thenReturn(
-            userChallenge);
+        when(userChallengeReader.findByUserIdAndChallengeId(userId, challengeId)).thenReturn(
+            Optional.of(userChallenge));
         // Mock ChallengeReviewReader to return an empty Optional
         when(challengeReviewReader.findByUserChallengeId(userChallenge.getId())).thenReturn(
             Optional.empty());
@@ -177,7 +177,7 @@ class RecordServiceTest {
 
         //assertNotNull(reviewId);  // 리뷰 ID가 null이 아닌지 확인
         //assertEquals(1L, reviewId);  // 리뷰 ID가 1L인지 확인
-        verify(userChallengeReader).getByUserIdAndChallengeId(userId, challengeId);
+        verify(userChallengeReader).findByUserIdAndChallengeId(userId, challengeId);
         verify(challengeReviewReader).findByUserChallengeId(userChallenge.getId());
         verify(challengeReviewStore).store(any());
     }


### PR DESCRIPTION
## 🔎 작업 내용

1. RestControllerAdvice에러 종류를 더 추가하였습니다.
2. 스웨거에서 API 더 보기 편하게 어노테이션 추가
3. 스웨거 URL profile에 따라 주소 다르도록 설정
4. 챌린지그룹조회에서 category를 optional로 받고, null일때, 전체조회로 변경작업수행
5. 챌린지그룹 조회 N+1 해결

## To Reviewers 📢
챌린지그룹 페이징 조회에서는 OneToMany관계인 challenge를 같이 모두 조회해야하는데
이를 기본적인 fetchJoin()을 사용하면 쿼리가 모든 challengeGroup와 challenge조회 후 메모리에서 정렬하게됩니다. 

이를 방지하기위해
1. count쿼리
2. challengeGroupId 페이징 쿼리
3. challengeGroup+challenge IN절 쿼리로 해결하였습니다


## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [x] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [x] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [x] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #54 